### PR TITLE
[HOPSWORKS-702] add python3 support for sparkmagic plotting with magics

### DIFF
--- a/sparkmagic/sparkmagic/livyclientlib/sparkstorecommand.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkstorecommand.py
@@ -70,11 +70,11 @@ class SparkStoreCommand(Command):
         else:
             command = u'{}.collect()'.format(command)
         # Unicode support has improved in Python 3 so we don't need to encode.
-        if encode_result:
-            print_command = '{}.encode("{}")'.format(constants.LONG_RANDOM_VARIABLE_NAME,
-                                                     conf.pyspark_dataframe_encoding())
-        else:
-            print_command = constants.LONG_RANDOM_VARIABLE_NAME
+        #if encode_result:
+        #    print_command = '{}.encode("{}")'.format(constants.LONG_RANDOM_VARIABLE_NAME,
+        #                                             conf.pyspark_dataframe_encoding())
+        #else:
+        print_command = constants.LONG_RANDOM_VARIABLE_NAME
         command = u'for {} in {}: print({})'.format(constants.LONG_RANDOM_VARIABLE_NAME,
                                                     command,
                                                     print_command)

--- a/sparkmagic/sparkmagic/livyclientlib/sqlquery.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sqlquery.py
@@ -78,11 +78,11 @@ class SQLQuery(ObjectWithGuid):
         else:
             command = u'{}.collect()'.format(command)
         # Unicode support has improved in Python 3 so we don't need to encode.
-        if encode_result:
-            print_command = '{}.encode("{}")'.format(constants.LONG_RANDOM_VARIABLE_NAME,
-                                                     conf.pyspark_dataframe_encoding())
-        else:
-            print_command = constants.LONG_RANDOM_VARIABLE_NAME
+        #if encode_result:
+        #    print_command = '{}.encode("{}")'.format(constants.LONG_RANDOM_VARIABLE_NAME,
+        #                                             conf.pyspark_dataframe_encoding())
+        #else:
+        print_command = constants.LONG_RANDOM_VARIABLE_NAME
         command = u'for {} in {}: print({})'.format(constants.LONG_RANDOM_VARIABLE_NAME,
                                                     command,
                                                     print_command)


### PR DESCRIPTION
Fixes erroneous JSON decoding of the dataframe.

Tested on a VM with python 2.7 and python 3.6 using this notebook: https://github.com/logicalclocks/hops-examples/blob/master/tensorflow/notebooks/Plotting/Data_Visualizations.ipynb