### PR TITLE
[HOPSWORKS-1153] Progress bar for multiple experiments

### DIFF
--- a/sparkmagic/sparkmagic/__init__.py
+++ b/sparkmagic/sparkmagic/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.12.5'
+__version__ = '0.12.7'
 
 from sparkmagic.serverextension.handlers import load_jupyter_server_extension
 

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -278,7 +278,11 @@ class Client(MessageSocket):
                         self.ipython_display.writeln("Wait for the maggy server...")
                     self.hb_sock.connect(self.server_addr)
                     break
-                except ConnectionRefusedError:
+                # throws ConnectionRefusedError if maggy is not ready yet
+                # throws TypeError if REST API returns no maggy address
+                # this happens when a second experiment is run from the same
+                # app with an old maggy version
+                except (ConnectionRefusedError, TypeError):
                     time.sleep(self.hb_interval)
                     pass
 

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -269,7 +269,18 @@ class Client(MessageSocket):
 
             # 3. Start thread running polling logs in Maggy.
             self.hb_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.hb_sock.connect(self.server_addr)
+
+            num_tries = 10
+            while num_tries > 0:
+                num_tries -= 1
+                try:
+                    if DEBUG:
+                        self.ipython_display.writeln("Wait for the maggy server...")
+                    self.hb_sock.connect(self.server_addr)
+                    break
+                except ConnectionRefusedError:
+                    time.sleep(self.hb_interval)
+                    pass
 
             if DEBUG:
                 self.ipython_display.writeln("Connected to the maggy server...")

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -282,6 +282,9 @@ class Client(MessageSocket):
                     time.sleep(self.hb_interval)
                     pass
 
+            if num_tries == 0:
+                raise Exception("Can't reach Maggy server. No progress information available. Job continues running anyway.")
+
             if DEBUG:
                 self.ipython_display.writeln("Connected to the maggy server...")
 

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -283,7 +283,7 @@ class Client(MessageSocket):
                     pass
 
             if num_tries == 0:
-                raise Exception("Can't reach Maggy server. No progress information available. Job continues running anyway.")
+                self.ipython_display.writeln("WARN: Can't reach Maggy server. No progress information and logs available. Job continues running anyway.")
 
             if DEBUG:
                 self.ipython_display.writeln("Connected to the maggy server...")


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1153

Maggy was changed to be able to run multiple experiments within the same yarn app id.
So maggy only registers once with Hopsworks and reuses the same port afterwards.
In this case sparkmagic gets the socket address of the server before maggy started the server again when a second experiment is run.
Sparkmagic will try 10 times to connect to the maggy server, if it fails, the heartbeat thread fails and will print a warning in Jupyter to tell the user that logging is not available, but job continues running. The job continues running, just without progress information below the Jupyter  Cell.