### PR TITLE
remove YARN from notebook UI when you start sparkmagic

### DIFF
--- a/sparkmagic/sparkmagic/utils/utils.py
+++ b/sparkmagic/sparkmagic/utils/utils.py
@@ -86,7 +86,7 @@ def records_to_dataframe(records_text, kind, coerce=None):
 
 def get_sessions_info_html(info_sessions, current_session_id):
     html = u"""<table>
-<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th></tr>""" + \
+<tr><th>ID</th><th>Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th></tr>""" + \
     u"".join([session.get_row_html(current_session_id) for session in info_sessions]) + \
     u"</table>"
 


### PR DESCRIPTION
### Description
Don't print "YARN" when a spark application starts.
Renamed YARN application_id to application_id

### Checklist
- [ X] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
